### PR TITLE
test: mock preventDefault in form submit handlers

### DIFF
--- a/src/components/_test/FormLogin.test.jsx
+++ b/src/components/_test/FormLogin.test.jsx
@@ -28,7 +28,7 @@ describe('FormLogin Component', () => {
   });
 
   const createFormWrapper = (customProps = {}) => {
-    const onSubmitHandler = vi.fn();
+    const onSubmitHandler = vi.fn((e) => e.preventDefault());
     const onChangeEmail = vi.fn();
     const onChangePassword = vi.fn();
     const Wrapper = () => {

--- a/src/components/_test/FormRegister.test.jsx
+++ b/src/components/_test/FormRegister.test.jsx
@@ -28,7 +28,7 @@ describe('FormRegister Component', () => {
   });
 
   const createFormWrapper = (customProps = {}) => {
-    const onSubmitHandler = vi.fn();
+    const onSubmitHandler = vi.fn((e) => e.preventDefault());
     const onChangeName = vi.fn();
     const onChangeEmail = vi.fn();
     const onChangePassword = vi.fn();


### PR DESCRIPTION
Ensure `preventDefault` is mocked in form submit handlers during tests to prevent actual form submission and allow controlled test execution.