### PR TITLE
Adds Discuss title to auth pages

### DIFF
--- a/src/layouts/AuthPageWrapper.jsx
+++ b/src/layouts/AuthPageWrapper.jsx
@@ -5,6 +5,7 @@ const AuthPageWrapper = ({ title, subtitle, children, linkAction }) => {
   return (
     <section className="auth-page flex-1 flex flex-col justify-center">
       <div className="auth-page__content max-w-sm w-full mx-auto">
+        <h1 className="text-3xl text-primary font-bold">Discuss</h1>
         <h2 className="font-semibold text-2xl mb-2">{title}</h2>
         <p className="mb-4">{subtitle}</p>
         {children}


### PR DESCRIPTION
Adds a consistent branding element to the authentication pages by including the "Discuss" title. This improves the user experience by providing visual context and reinforcing brand identity.